### PR TITLE
Add production flag for `npm run build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "jest",
     "start": "webpack --watch",
-    "build": "webpack",
+    "build": "webpack -p",
     "lint": "./node_modules/.bin/eslint ./"
   },
   "author": {


### PR DESCRIPTION
That way webpack can optimize the resulting bundle.

:shipit: 